### PR TITLE
Allow nested referenceFields with cacheCount

### DIFF
--- a/cacheCount.js
+++ b/cacheCount.js
@@ -16,6 +16,7 @@ Mongo.Collection.prototype.cacheCount = function(options) {
   let cacheField = options.cacheField
   let referenceField = options.referenceField
   let watchedFields = _.union([referenceField], _.keys(selector))
+  const topFields = _.uniq(watchedFields.map(field => field.split('.')[0]));
 
   if(referenceField.split(/[.:]/)[0] == cacheField.split(/[.:]/)[0]){
     throw new Error('referenceField and cacheField must not share the same top field')
@@ -43,7 +44,7 @@ Mongo.Collection.prototype.cacheCount = function(options) {
   })
 
   childCollection.after.update((userId, child, changedFields) => {
-    if(_.intersection(changedFields, watchedFields).length){
+    if(_.intersection(changedFields, topFields).length){
       update(child)
       update(this.previous)
     }


### PR DESCRIPTION
This is already working in regular cache
Checks topLevel fields instead of watchedFields to start the update.